### PR TITLE
Syntax highlighting for table names enclosed in backticks (``) & LIMIT keyword

### DIFF
--- a/syntax/sql/sqlx_bigquery.vim
+++ b/syntax/sql/sqlx_bigquery.vim
@@ -95,6 +95,7 @@ syn keyword sqlxSqlStatement qualify
 syn keyword sqlxSqlStatement truncate
 syn keyword sqlxSqlStatement update
 syn keyword sqlxSqlStatement window
+syn keyword sqlxSqlStatement limit
 
 
 " Operators

--- a/syntax/sqlx.vim
+++ b/syntax/sqlx.vim
@@ -25,7 +25,7 @@ syn keyword sqlxTodo TODO FIXME XXX DEBUG NOTE contained
 
 " Strings
 syn match  sqlxSqlSpecial contained "\v\\%(x\x\x|u%(\x{4}|\{\x{4,5}})|c\u|.)"
-syn region sqlxSqlString  start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1+ end=+$+ contains=sqlxSqlSpecial extend
+syn region sqlxSqlString  start=+\z(["'`]\)+  skip=+\\\%(\z1\|$\)+  end=+\z1+ end=+$+ contains=sqlxSqlSpecial extend
 
 
 " Comments


### PR DESCRIPTION
This pull request enables -
1. Table names `project_id.dataset.table` enclosed in backticks (``) to have syntax highligting
2. `LIMIT` keyword has correct syntax highlighting
Example ->
<img width="470" alt="CleanShot 2023-08-18 at 22 48 48@2x" src="https://github.com/andres-lowrie/vim-sqlx/assets/34306898/e90cfeed-18e8-4021-9606-1a11a52a06c6">
